### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     # Build runner layout
     - name: Build & Layout Release
@@ -75,7 +75,7 @@ jobs:
     # Upload runner package tar.gz/zip as artifact
     - name: Publish Artifact
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: runner-package-${{ matrix.runtime }}
         path: |

--- a/.github/workflows/close-bugs-bot.yml
+++ b/.github/workflows/close-bugs-bot.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           close-issue-message: "This issue does not seem to be a problem with the runner application, it concerns the GitHub actions platform more generally. Could you please post your feedback on the [GitHub Community Support Forum](https://github.com/orgs/community/discussions/categories/actions) which is actively monitored. Using the forum ensures that we route your problem to the correct team. 😃"
           exempt-issue-labels: "keep"

--- a/.github/workflows/close-features-bot.yml
+++ b/.github/workflows/close-features-bot.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           close-issue-message: "Thank you for your interest in the runner application and taking the time to provide your valuable feedback. We kindly ask you to redirect this feedback to the [GitHub Community Support Forum](https://github.com/orgs/community/discussions/categories/actions-and-packages) which our team actively monitors and would be a better place to start a discussion for new feature requests in GitHub Actions. For more information on this policy please [read our contribution guidelines](https://github.com/actions/runner#contribute). 😃"
           exempt-issue-labels: "keep"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -38,4 +38,4 @@ jobs:
       working-directory: src
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1

--- a/.github/workflows/docker-buildx-upgrade.yml
+++ b/.github/workflows/docker-buildx-upgrade.yml
@@ -17,7 +17,7 @@ jobs:
       BUILDX_CURRENT_VERSION: ${{ steps.check_buildx_version.outputs.CURRENT_VERSION }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Check Docker version
         id: check_docker_version
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       
       - name: Update Docker version
         shell: bash

--- a/.github/workflows/dotnet-upgrade.yml
+++ b/.github/workflows/dotnet-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
       DOTNET_CURRENT_MAJOR_MINOR_VERSION: ${{ steps.fetch_current_version.outputs.DOTNET_CURRENT_MAJOR_MINOR_VERSION }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Get current major minor version
         id: fetch_current_version
         shell: bash
@@ -89,7 +89,7 @@ jobs:
     if: ${{ needs.dotnet-update.outputs.SHOULD_UPDATE == 1 && needs.dotnet-update.outputs.BRANCH_EXISTS == 0 }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         ref: feature/dotnetsdk-upgrade/${{ needs.dotnet-update.outputs.DOTNET_LATEST_MAJOR_MINOR_PATCH_VERSION }}
     - name: Create Pull Request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/releases/') || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     # Make sure ./releaseVersion match ./src/runnerversion
     # Query GitHub release ensure version is not used
     - name: Check version
-      uses: actions/github-script@v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
@@ -86,7 +86,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     # Build runner layout
     - name: Build & Layout Release
@@ -118,7 +118,7 @@ jobs:
     # Upload runner package tar.gz/zip as artifact.
     - name: Publish Artifact
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: runner-packages-${{ matrix.runtime }}
         path: |
@@ -129,41 +129,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     # Download runner package tar.gz/zip produced by 'build' job
     - name: Download Artifact (win-x64)
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: runner-packages-win-x64
         path: ./
     - name: Download Artifact (win-arm64)
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: runner-packages-win-arm64
         path: ./
     - name: Download Artifact (osx-x64)
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: runner-packages-osx-x64
         path: ./
     - name: Download Artifact (osx-arm64)
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: runner-packages-osx-arm64
         path: ./
     - name: Download Artifact (linux-x64)
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: runner-packages-linux-x64
         path: ./
     - name: Download Artifact (linux-arm)
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: runner-packages-linux-arm
         path: ./
     - name: Download Artifact (linux-arm64)
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: runner-packages-linux-arm64
         path: ./
@@ -171,7 +171,7 @@ jobs:
     # Create ReleaseNote file
     - name: Create ReleaseNote
       id: releaseNote
-      uses: actions/github-script@v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
@@ -201,7 +201,7 @@ jobs:
         echo "${{needs.build.outputs.linux-arm64-sha}}  actions-runner-linux-arm64-${{ steps.releaseNote.outputs.version }}.tar.gz" | shasum -a 256 -c
 
     # Create GitHub release
-    - uses: actions/create-release@master
+    - uses: actions/create-release@89e8dc236279a907f495cdc4ebff2056b7036b3d # master
       id: createRelease
       name: Create ${{ steps.releaseNote.outputs.version }} Runner Release
       env:
@@ -214,7 +214,7 @@ jobs:
 
     # Upload release assets (full runner packages)
     - name: Upload Release Asset (win-x64)
-      uses: actions/upload-release-asset@v1.0.2
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -224,7 +224,7 @@ jobs:
         asset_content_type: application/octet-stream
 
     - name: Upload Release Asset (win-arm64)
-      uses: actions/upload-release-asset@v1.0.2
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -234,7 +234,7 @@ jobs:
         asset_content_type: application/octet-stream
 
     - name: Upload Release Asset (linux-x64)
-      uses: actions/upload-release-asset@v1.0.2
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -244,7 +244,7 @@ jobs:
         asset_content_type: application/octet-stream
 
     - name: Upload Release Asset (osx-x64)
-      uses: actions/upload-release-asset@v1.0.2
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -254,7 +254,7 @@ jobs:
         asset_content_type: application/octet-stream
 
     - name: Upload Release Asset (osx-arm64)
-      uses: actions/upload-release-asset@v1.0.2
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -264,7 +264,7 @@ jobs:
         asset_content_type: application/octet-stream
 
     - name: Upload Release Asset (linux-arm)
-      uses: actions/upload-release-asset@v1.0.2
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -274,7 +274,7 @@ jobs:
         asset_content_type: application/octet-stream
 
     - name: Upload Release Asset (linux-arm64)
-      uses: actions/upload-release-asset@v1.0.2
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -296,11 +296,11 @@ jobs:
       IMAGE_NAME: ${{ github.repository_owner }}/actions-runner
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Compute image version
         id: image
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs');
@@ -309,10 +309,10 @@ jobs:
             core.setOutput('version', runnerVersion);
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -320,7 +320,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./images
           platforms: |
@@ -338,7 +338,7 @@ jobs:
             org.opencontainers.image.licenses=MIT
 
       - name: Generate attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           stale-issue-message: "This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 15 days."
           close-issue-message: "This issue was closed because it has been stalled for 15 days with no activity."


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/upload-artifact@v4` -> `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
  - Version: v4.6.2 | Latest: v3.2.2 | Release age: 23d
  - Commit: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

- `actions/stale@v9` -> `actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0`
  - Version: v9.1.0 | Latest: v10.2.0 | Release age: 52d
  - Commit: https://github.com/actions/stale/commit/5bef64f19d7facfb25b37b414482c7164d639639

- `github/codeql-action/init@v3` -> `github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1`
  - Version: v3.35.1 | Latest: v4.35.1 | Release age: 13d
  - Commit: https://github.com/github/codeql-action/commit/5c8a8a642e79153f5d047b10ec1cba1d1cc65699
  - Warnings: 2 security advisory(ies) found, Action has 2 known advisory(ies)

- `github/codeql-action/analyze@v3` -> `github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1`
  - Version: v3.35.1 | Latest: v4.35.1 | Release age: 13d
  - Commit: https://github.com/github/codeql-action/commit/5c8a8a642e79153f5d047b10ec1cba1d1cc65699
  - Warnings: 2 security advisory(ies) found, Action has 2 known advisory(ies)

- `actions/github-script@v7.0.1` -> `actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1`
  - Version: v7.0.1 | Latest: v9.0.0 | Release age: 217d
  - Commit: https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea
  - Warnings: Latest release v9.0.0 is only 0 day(s) old (< 7 days). Using previous safe release.

- `actions/download-artifact@v4` -> `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0`
  - Version: v4.3.0 | Latest: v3.1.0-node20 | Release age: 23d
  - Commit: https://github.com/actions/download-artifact/commit/d3f86a106a0bac45b974a628896c90dbdf5c8093
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `actions/create-release@master` -> `actions/create-release@89e8dc236279a907f495cdc4ebff2056b7036b3d # master`
  - Version: master | Latest: v1.1.4 | Release age: 2033d
  - Commit: https://github.com/actions/create-release/commit/89e8dc236279a907f495cdc4ebff2056b7036b3d

- `actions/upload-release-asset@v1.0.2` -> `actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2`
  - Version: v1.0.2 | Latest: v1.0.2 | Release age: 2250d
  - Commit: https://github.com/actions/upload-release-asset/commit/e8f9f06c4b078e705bd2ea027f0926603fc9b4d5

- `docker/setup-buildx-action@v3` -> `docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0`
  - Version: v3.12.0 | Latest: v4.0.0 | Release age: 35d
  - Commit: https://github.com/docker/setup-buildx-action/commit/8d2750c68a42422c14e847fe6c8ac0403b4cbd6f

- `docker/login-action@v3` -> `docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0`
  - Version: v3.7.0 | Latest: v4.1.0 | Release age: 7d
  - Commit: https://github.com/docker/login-action/commit/c94ce9fb468520275223c153574b00df6fe4bcc9

- `docker/build-push-action@v6` -> `docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2`
  - Version: v6.19.2 | Latest: v7.0.0 | Release age: 35d
  - Commit: https://github.com/docker/build-push-action/commit/10e90e3645eae34f1e60eeb005ba3a3d33f178e8

- `actions/attest-build-provenance@v2` -> `actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0`
  - Version: v2.4.0 | Latest: v4.1.0 | Release age: 42d
  - Commit: https://github.com/actions/attest-build-provenance/commit/e8998f949152b193b063cb0ec769d69d929409be


### Files modified

- `.github/workflows/build.yml`
- `.github/workflows/close-bugs-bot.yml`
- `.github/workflows/close-features-bot.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/docker-buildx-upgrade.yml`
- `.github/workflows/dotnet-upgrade.yml`
- `.github/workflows/release.yml`
- `.github/workflows/stale-bot.yml`

### Security warnings

- 2 security advisory(ies) found
- Action has 2 known advisory(ies)
- Latest release v9.0.0 is only 0 day(s) old (< 7 days). Using previous safe release.
- 1 security advisory(ies) found
- Action has 1 known advisory(ies)